### PR TITLE
Introduce 'mocks' target in Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,8 @@ test: bins
 	@echo testing...
 	@GO111MODULE=on go test -v -race -covermode=atomic -coverprofile=obscurer.coverprofile github.com/freerware/obscurer
 
+mocks:
+	@mockgen -source=store.go -destination=./internal/mock/store.go -package=mock -mock_names=Store=Store
+
 benchmark: bins
 	@GO111MODULE=on go test -run XXX -bench .


### PR DESCRIPTION
**Description**

Introduces the `mocks` target in `Makefile`.

**Rationale**

Whenever we make changes to the definitions of mocked types, we should be able to quickly and simply regenerate out mocks.

**Suggested Version**

`v0.0.3`.

**Example Usage**

`make mocks`
